### PR TITLE
Configure CI workflow to compile AceTime library example

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -53,6 +53,7 @@ jobs:
         - ~/Arduino/libraries/MFRC522/examples/rfid_read_personal_data
         - ~/Arduino/libraries/MFRC522/examples/rfid_write_personal_data
         - ~/Arduino/libraries/WiFi101/examples
+        - ~/Arduino/libraries/AceTime/examples/HelloDateTime
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This change causes the "Compile Examples" CI workflow to compile AceTime library's "HelloDateTime" example sketch for
every board in the job matrix.